### PR TITLE
Add default user in cisco devices

### DIFF
--- a/Add default user in cisco
+++ b/Add default user in cisco
@@ -1,0 +1,19 @@
+from netmiko import ConnectHandler
+
+RSLAB_TERMINAL1 = {
+	'device_type': 'cisco_ios',
+	'ip': '129.119.59.2',
+	'username': 'xxx',
+	'password': 'xxx',
+	} 
+
+net_connect = ConnectHandler(**RSLAB_TERMINAL1)
+
+port = raw_input('Creating the default user admin and setting the password for the same')
+
+
+net_connect.send_command_expect("username admin password xxxxxx"\n")
+
+net_connect.send_command("\n")
+
+print ("User created. Please try to login as admin user to verify")


### PR DESCRIPTION
A Python code using netmiko Library to create a default user and setting the password for the same on your cisco devices. This is a basic script which can modified and used to automate the hardening of your network devices.